### PR TITLE
Add modification API

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,4 +23,7 @@ jobs:
       - name: Install dependencies
         run: dart pub get
       - name: Run tests
-        run: dart test
+        run: |
+          git config --global user.email "dash@flutter.dev"
+          git config --global user.name "Dash"
+          dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+- Add modification API `BumpVersionCommand.addModification(...)` #5
+
 ## 1.1.1
 - Add topics to `pubspec.yaml`
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,13 @@ runner..addCommand(BumpVersionCommand()..addModification(bumpChangelog));
 ```
 
 ```dart
-void bumpChangelog(
-    DartPackage package, Version oldVersion, Version newVersion) {
+Future<void> bumpChangelog(DartPackage package, Version oldVersion, Version newVersion) async {
+  final readme = package.root.file('README.md');
+  final content = readme.readAsStringSync();
 
-  final versionFile = package.root.file('CHANGELOG.md');
-  final content = versionFile.readAsStringSync();
-
-  // TODO replace the version
-  
-  versionFile.writeAsStringSync(newContent);
+  final versionRegex = RegExp(r'my_package: \^(.+)');
+  final update = content.replaceFirst(versionRegex, 'my_package: ^${newVersion.canonicalizedVersion}');
+  readme.writeAsStringSync(update);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A plugin for [sidekick CLIs](https://pub.dev/packages/sidekick).
 
 ## Description
 
-Bumps the version of a package.  
-
-Take a look at the available [sidekick plugins on pub.dev](https://pub.dev/packages?q=dependency%3Asidekick_core).
-
+- Bumps the version of a package (major, minor, patch)
+- Optionally commits the version bump
+- modification API to adjust other files (e.g. `CHANGELOG.md`)
 
 ## Installation
 
@@ -39,6 +38,25 @@ One of `--minor`, `--patch`, `--major` is required. This controls how the versio
 E.g. current version is `1.2.3`, `--minor` is selected -> updates to `1.3.0`.  
 
 If `--commit` is given, the version bump is automatically committed.
+
+## Modification API
+
+```dart
+runner..addCommand(BumpVersionCommand()..addModification(bumpChangelog));
+```
+
+```dart
+void bumpChangelog(
+    DartPackage package, Version oldVersion, Version newVersion) {
+
+  final versionFile = package.root.file('CHANGELOG.md');
+  final content = versionFile.readAsStringSync();
+
+  // TODO replace the version
+  
+  versionFile.writeAsStringSync(newContent);
+}
+```
 
 ## License
 

--- a/test/add_modification_test.dart
+++ b/test/add_modification_test.dart
@@ -1,0 +1,73 @@
+import 'package:phntmxyz_bump_version_sidekick_plugin/phntmxyz_bump_version_sidekick_plugin.dart';
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_test/sidekick_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('executes sync modification', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      await dir.file('pubspec.yaml').appendString('\nversion: 1.2.3');
+      final readme = dir.file('README.md');
+      readme.writeAsStringSync('''
+# Package
+
+```yaml
+dependencies:
+  my_package: ^1.2.3
+```
+      ''');
+      final runner = initializeSidekick(
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(
+        BumpVersionCommand()
+          ..addModification((package, oldVersion, newVersion) {
+            final versionRegex = RegExp(r'my_package: \^(.+)');
+            final update = readme.readAsStringSync().replaceFirst(
+                  versionRegex,
+                  'my_package: ^${newVersion.canonicalizedVersion}',
+                );
+            readme.writeAsStringSync(update);
+          }),
+      );
+      await runner.run(['bump-version', '--minor']);
+
+      expect(readme.readAsStringSync(), contains('my_package: ^1.3.0'));
+    });
+  });
+
+  test('executes async modification', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      await dir.file('pubspec.yaml').appendString('\nversion: 1.2.3');
+      final readme = dir.file('README.md');
+      readme.writeAsStringSync('''
+# Package
+
+```yaml
+dependencies:
+  my_package: ^1.2.3
+```
+      ''');
+      final runner = initializeSidekick(
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(
+        BumpVersionCommand()
+          ..addModification((package, oldVersion, newVersion) async {
+            // make it really async
+            await Future.delayed(const Duration(milliseconds: 200));
+
+            final versionRegex = RegExp(r'my_package: \^(.+)');
+            final update = readme.readAsStringSync().replaceFirst(
+                  versionRegex,
+                  'my_package: ^${newVersion.canonicalizedVersion}',
+                );
+            readme.writeAsStringSync(update);
+          }),
+      );
+      await runner.run(['bump-version', '--minor']);
+
+      expect(readme.readAsStringSync(), contains('my_package: ^1.3.0'));
+    });
+  });
+}

--- a/test/bump_version_command_test.dart
+++ b/test/bump_version_command_test.dart
@@ -92,7 +92,7 @@ void main() {
           dartSdkPath: fakeDartSdk().path,
         );
         runner.addCommand(BumpVersionCommand());
-        runner.run(['bump-version', '--major', '--commit']);
+        await runner.run(['bump-version', '--major', '--commit']);
 
         final lastCommitMessage = 'git -C ${dir.path} show -s --format=%s'
             .start(progress: Progress.capture(), nothrow: true)

--- a/test/bump_version_command_test.dart
+++ b/test/bump_version_command_test.dart
@@ -81,7 +81,6 @@ void main() {
   group('commit', () {
     test('works when pubspec has local changes', () async {
       await insideFakeProjectWithSidekick((dir) async {
-        print(dir);
         'git init -q ${dir.path} '.run;
         'git -C ${dir.path} add .'.run;
         await dir.file('pubspec.yaml').appendString('\nversion: 1.2.3');

--- a/test/bump_version_command_test.dart
+++ b/test/bump_version_command_test.dart
@@ -79,40 +79,52 @@ void main() {
   });
 
   group('commit', () {
-    test('throws when pubspec has local changes', () async {
+    test('works when pubspec has local changes', () async {
       await insideFakeProjectWithSidekick((dir) async {
+        print(dir);
         'git init -q ${dir.path} '.run;
         'git -C ${dir.path} add .'.run;
-        _gitCommit(dir);
         await dir.file('pubspec.yaml').appendString('\nversion: 1.2.3');
+        _gitCommit(dir);
+        // local change
+        await dir.file('pubspec.yaml').appendString('\n\n#comment');
         final runner = initializeSidekick(
           dartSdkPath: fakeDartSdk().path,
         );
         runner.addCommand(BumpVersionCommand());
+        runner.run(['bump-version', '--major', '--commit']);
+
+        final lastCommitMessage = 'git -C ${dir.path} show -s --format=%s'
+            .start(progress: Progress.capture(), nothrow: true)
+            .lines
+            .first;
+        expect(lastCommitMessage, contains('Bump version to 2.0.0'));
         expect(
-          () => runner.run(['bump-version', '--major', '--commit']),
-          throwsA(contains('There are local changes')),
+          dir.file('pubspec.yaml').readAsStringSync(),
+          contains('#comment'),
+        );
+        expect(
+          dir.file('pubspec.yaml').readAsStringSync(),
+          contains('version: 2.0.0'),
         );
       });
     });
 
-    test('throws when there are staged files', () async {
+    test('staged files are restored', () async {
       await insideFakeProjectWithSidekick((dir) async {
         await dir.file('pubspec.yaml').appendString('\nversion: 1.2.3');
         'git init -q ${dir.path} '.run;
         'git -C ${dir.path} add .'.run;
         _gitCommit(dir);
-        dir.file('foo').writeAsStringSync('foo');
+        final fooFile = dir.file('foo')..writeAsStringSync('foo');
         'git -C ${dir.path} add foo'.run;
 
         final runner = initializeSidekick(
           dartSdkPath: fakeDartSdk().path,
         );
         runner.addCommand(BumpVersionCommand());
-        expect(
-          () => runner.run(['bump-version', '--major', '--commit']),
-          throwsA(contains('There are staged files')),
-        );
+        expect(fooFile.existsSync(), isTrue);
+        expect(fooFile.readAsStringSync(), 'foo');
       });
     });
 


### PR DESCRIPTION

```dart
runner..addCommand(BumpVersionCommand()..addModification(bumpChangelog));
```

```dart
Future<void> bumpChangelog(DartPackage package, Version oldVersion, Version newVersion) async {
  final readme = package.root.file('README.md');
  final content = readme.readAsStringSync();

  final versionRegex = RegExp(r'my_package: \^(.+)');
  final update = content.replaceFirst(versionRegex, 'my_package: ^${newVersion.canonicalizedVersion}');
  readme.writeAsStringSync(update);
}
```