### PR TITLE
Update pubspec manager

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -9,7 +9,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: dart:3.5.0
+      image: dart:3.6.0
 
     steps:
       - uses: actions/checkout@v4    

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # Always keep support to at least 2 stable versions
-        version: [ "3.5.0", "latest" ]
+        version: [ "3.6.0", "latest" ]
 
     container:
       image: dart:${{ matrix.version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:3.5.0
+      image: dart:3.6.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # Always keep support to at least 2 stable versions
-        version: [ "3.5.0", "latest" ]
+        version: [ "3.6.0", "latest" ]
 
     container:
       image: dart:${{ matrix.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
-## 2.0.1
+## 2.1.0
 - Update to `pubspec_manager` 3.0.0
+- Update to Dart 3.6
 
 ## 2.0.0
 - Added `pubspec_manager` as dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.0.1
+- Update to `pubspec_manager` 3.0.0
 
 ## 2.0.0
 - Added `pubspec_manager` as dependency

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  pubspec_manager: ^1.0.2
+  pubspec_manager: ^3.0.0
   sidekick_core: ^3.0.0
   yaml_edit: ^2.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phntmxyz_bump_version_sidekick_plugin
 description: Generated sidekick plugin (template shared-command)
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/phntmxyz/bump_version_sidekick_plugin
 issue_tracker: https://github.com/phntmxyz/bump_version_sidekick_plugin/issues
 topics:
@@ -9,7 +9,7 @@ topics:
   - sidekick-plugin
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   pubspec_manager: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phntmxyz_bump_version_sidekick_plugin
 description: Generated sidekick plugin (template shared-command)
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/phntmxyz/bump_version_sidekick_plugin
 issue_tracker: https://github.com/phntmxyz/bump_version_sidekick_plugin/issues
 topics:


### PR DESCRIPTION
I tried to install this plugin but got an resolve error because of the used `pubspec_manager` version.
It works with version `3.0.0` and min Dart version 3.6

> Because every version of sidekick_test from git depends on pubspec_manager ^3.0.0 and phntmxyz_bump_version_sidekick_plugin depends on pubspec_manager ^1.0.2, sidekick_test from git is forbidden.
So, because phntmxyz_bump_version_sidekick_plugin depends on sidekick_test from git, version solving failed.